### PR TITLE
Fix broken link in docs

### DIFF
--- a/index.json
+++ b/index.json
@@ -104,7 +104,7 @@
         "metadata_version": "3",
         "type": "database",
         "dialect": "postgres",
-        "title": "Permissions: Extensibile Attribute Permissions",
+        "title": "Permissions: Extensible Attribute Permissions",
         "description": "Using the `exists` operator to create permissions from a user attribute table, as well as extensible attributes using JSONB. ",
         "category": "Core Concepts",
         "relativeFolderPath": "/postgres/permissions-extensible-attributes-jsonb"

--- a/postgres/permissions-extensible-attributes-jsonb/config.json
+++ b/postgres/permissions-extensible-attributes-jsonb/config.json
@@ -1,7 +1,7 @@
 {
     "longDescription": "Attribute-based permissions are a powerful way to be able to be able to model user permissions. \n\nIn this example, we'll be creating a granting a user special moderator permissions (ability to see and edit all chats) based on an JSONB entry found in a `user_attributes` table. \n\n**Note:** To test this user role, try entering a `x-hasura-user-id` entry when using your GraphiQL editor in the API tab.",
     "imageUrl": "diagram.png",
-    "blogPostLink": "https://hasura.io/docs/latest/graphql/core/auth/authorization",
+    "blogPostLink": "https://hasura.io/docs/latest/graphql/core/auth/authorization/index.html",
     "sqlFiles": ["migration.sql"],
     "metadataUrl": "metadata.json"
 }


### PR DESCRIPTION
The link "Permissions: Extensible Attribute Permissions" to the blog was incorrect. PR updates it from `https://hasura.io/docs/latest/auth/authorization/` to `https://hasura.io/docs/latest/graphql/core/auth/authorization/index.html`